### PR TITLE
feat(gitops): PR list + select + send to merge-train (dry-run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ cargo run --features host --manifest-path src-tauri/Cargo.toml
 
 Runs are **dry-run** by default. The host restricts filesystem access to `ade/flows/` and `kit/flows/`, only allows `git`, `gh`, `python3`, and `bash` commands, enforces a ~60s timeout, and caps output at ~200 KB.
 
+## Select PRs → Merge Train
+
+- Reload PRs (needs host & `gh`)
+- Select several → “Send to Merge Train”
+- Go to Flows → Merge Train → Preview/Run (dry-run)
+
 ## Continuous Integration
 
 The project relies on a GitHub Actions workflow to verify changes. Each run performs the following steps:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { FlowsPane } from "./components/FlowsPane";
+import { PRPane } from "./components/PRPane";
 
 export function App() {
   return (
     <div style={{ fontFamily: "ui-sans-serif, system-ui", padding: 16 }}>
       <h1>ADE-Workbench</h1>
-      <p>Flows discovery (repo-local via Tauri, fallback to bundled).</p>
-      <FlowsPane />
+      <p>Flows discovery (repo-local in dev) and GitOps helpers.</p>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <PRPane />
+        <FlowsPane />
+      </div>
     </div>
   );
 }

--- a/src/components/PRPane.tsx
+++ b/src/components/PRPane.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { hasTauri } from "../lib/host";
+import { listOpenPRs, type PR } from "../lib/gh";
+import { seedMergeTrainRefs } from "../lib/flowLaunch";
+
+export function PRPane() {
+  const [prs, setPrs] = React.useState<PR[]>([]);
+  const [sel, setSel] = React.useState<Record<number, boolean>>({});
+  const [err, setErr] = React.useState<string>("");
+  const [loading, setLoading] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    if (!hasTauri) { setErr("Host unavailable — paste PRs manually below."); return; }
+    setLoading(true);
+    try { setPrs(await listOpenPRs()); setErr(""); }
+    catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    finally { setLoading(false); }
+  }, []);
+
+  React.useEffect(() => { load(); }, [load]);
+
+  const selectedRefs = React.useMemo(() => {
+    const picked = prs.filter(p => sel[p.number]);
+    // Prefer branch refs; fallback to PR numbers
+    if (picked.length) return picked.map(p => p.headRefName || String(p.number)).join(" ");
+    return "";
+  }, [prs, sel]);
+
+  function toggle(n: number) {
+    setSel(s => ({ ...s, [n]: !s[n] }));
+  }
+
+  function copyRefs() {
+    if (!selectedRefs) return;
+    navigator.clipboard.writeText(selectedRefs).catch(e => setErr(`Copy failed: ${e}`));
+  }
+
+  function sendToMergeTrain() {
+    if (!selectedRefs) return;
+    seedMergeTrainRefs(selectedRefs);
+    // lightweight toast:
+    alert(`Seeded merge-train refs:\n${selectedRefs}\nOpen the Flows pane → Merge Train → Preview/Run.`);
+  }
+
+  return (
+    <div style={{ padding: 12 }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <h2>PRs</h2>
+        <button onClick={load} disabled={loading} style={{ padding: "4px 10px" }}>
+          {loading ? "Reload…" : "Reload"}
+        </button>
+      </div>
+      {err && <div style={{ color: "#b00", marginTop: 6 }}>{err}</div>}
+
+      {hasTauri && prs.length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          {prs.map(p => (
+            <label key={p.number} style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 4px" }}>
+              <input type="checkbox" checked={!!sel[p.number]} onChange={() => toggle(p.number)} />
+              <span style={{ fontWeight: 600 }}>#{p.number}</span>
+              <span>{p.title}</span>
+              <span style={{ fontSize: 12, opacity: 0.7, marginLeft: "auto" }}>{p.headRefName}</span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
+        <button onClick={copyRefs} disabled={!selectedRefs}>Copy refs</button>
+        <button onClick={sendToMergeTrain} disabled={!selectedRefs}>Send to Merge Train</button>
+      </div>
+
+      {!hasTauri && (
+        <ManualFallback />
+      )}
+    </div>
+  );
+}
+
+function ManualFallback() {
+  const [raw, setRaw] = React.useState("");
+  const refs = raw.trim().replace(/\s+/g, " ");
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div style={{ fontSize: 13, opacity: 0.75, marginBottom: 6 }}>
+        Host is unavailable. Paste PR numbers or branch names (space-separated).
+      </div>
+      <textarea rows={3} style={{ width: "100%", fontFamily: "monospace" }} value={raw} onChange={(e)=>setRaw(e.target.value)} />
+      <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+        <button onClick={() => navigator.clipboard.writeText(refs)} disabled={!refs}>Copy refs</button>
+        <button onClick={() => { seedMergeTrainRefs(refs); alert(`Seeded merge-train refs:\n${refs}`); }} disabled={!refs}>
+          Send to Merge Train
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/flowLaunch.ts
+++ b/src/lib/flowLaunch.ts
@@ -1,0 +1,12 @@
+const KEY = (id: string) => `flow_inputs/${id}`;
+export function seedMergeTrainRefs(refs: string) {
+  try {
+    const id = "merge-train";
+    const raw = localStorage.getItem(KEY(id));
+    const curr = raw ? JSON.parse(raw) : {};
+    const next = { ...curr, refs };
+    localStorage.setItem(KEY(id), JSON.stringify(next));
+  } catch (e) {
+    console.error("Failed to seed merge-train inputs:", e);
+  }
+}

--- a/src/lib/gh.ts
+++ b/src/lib/gh.ts
@@ -1,0 +1,26 @@
+import { hostRun, hasTauri } from "./host";
+
+export type PR = {
+  number: number;
+  title: string;
+  headRefName: string;
+  headRepositoryOwner?: { login: string };
+};
+
+export async function listOpenPRs(): Promise<PR[]> {
+  if (!hasTauri) throw new Error("host-unavailable");
+  const args = [
+    "pr","list",
+    "--state","open",
+    "--json","number,title,headRefName,headRepositoryOwner",
+    "--limit","100"
+  ];
+  const res = await hostRun("gh", args, /*dryRun*/ false);
+  if (res.status !== 0) throw new Error(res.stderr || "gh pr list failed");
+  try {
+    const data = JSON.parse(res.stdout) as PR[];
+    return Array.isArray(data) ? data : [];
+  } catch (e) {
+    throw new Error("failed to parse gh output");
+  }
+}

--- a/tests/gh_parse.spec.ts
+++ b/tests/gh_parse.spec.ts
@@ -1,0 +1,6 @@
+import { describe, it, expect } from "vitest";
+
+it("placeholder", () => {
+  // no external calls — just ensuring tests still run
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add host helper to fetch open PRs via gh
- seed merge-train refs into localStorage
- include PR panel with selection, copy, and merge-train send actions

## Testing
- `npm run build`
- `npm test`
- `npm run tauri:check`


------
https://chatgpt.com/codex/tasks/task_e_68bf46e35e088320ab312de9479b210f