### PR TITLE
feat(workspace): staged/unstaged file list + unified diff viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ Runs are **dry-run** by default. The host restricts filesystem access to `ade/fl
 - Select several → “Send to Merge Train”
 - Go to Flows → Merge Train → Preview/Run (dry-run)
 
+## Workspace & Diff
+
+- Requires host and `git` in PATH.
+- Shows staged/unstaged files and diff for selection.
+- Read-only; no stage/unstage actions (coming later).
+
 ## Continuous Integration
 
 The project relies on a GitHub Actions workflow to verify changes. Each run performs the following steps:
+
 - `npm run build` – type check and compile the frontend code.
 - `npm test` – execute the unit test suite.
 - `npm run tauri:check` – ensure the Rust backend compiles cleanly.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlowsPane } from "./components/FlowsPane";
 import { PRPane } from "./components/PRPane";
+import { WorkspacePane } from "./components/WorkspacePane";
 
 export function App() {
   return (
@@ -10,6 +11,9 @@ export function App() {
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
         <PRPane />
         <FlowsPane />
+        <div style={{ gridColumn: "1 / span 2" }}>
+          <WorkspacePane />
+        </div>
       </div>
     </div>
   );

--- a/src/components/WorkspacePane.tsx
+++ b/src/components/WorkspacePane.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { hasTauri } from "../lib/host";
+import { gitStatus, gitDiffFile, type FileChange } from "../lib/git";
+
+export function WorkspacePane() {
+  const [files, setFiles] = React.useState<FileChange[]>([]);
+  const [err, setErr] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [sel, setSel] = React.useState<{ path: string; staged: boolean } | null>(null);
+  const [diff, setDiff] = React.useState("");
+
+  const load = React.useCallback(async () => {
+    if (!hasTauri) {
+      setErr("Host unavailable — workspace requires host.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const f = await gitStatus();
+      setFiles(f);
+      setErr("");
+      // auto-select first file if none selected
+      if (!sel && f.length) setSel({ path: f[0].path, staged: f[0].staged });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [sel]);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  React.useEffect(() => {
+    (async () => {
+      if (!sel) {
+        setDiff("");
+        return;
+      }
+      try {
+        setDiff(await gitDiffFile(sel.path, sel.staged));
+      } catch (e) {
+        setDiff(e instanceof Error ? e.message : String(e));
+      }
+    })();
+  }, [sel]);
+
+  const staged = files.filter((f) => f.staged);
+  const unstaged = files.filter((f) => !f.staged);
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "320px 1fr", gap: 12, minHeight: 360 }}>
+      <div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <h2>Workspace</h2>
+          <button onClick={load} disabled={loading} style={{ padding: "4px 10px" }}>
+            {loading ? "Reload…" : "Reload"}
+          </button>
+        </div>
+        {err && <div style={{ color: "#b00", marginTop: 6 }}>{err}</div>}
+
+        <Section title={`Staged (${staged.length})`}>
+          {staged.length === 0 ? (
+            <Empty />
+          ) : (
+            staged.map((f) => (
+              <FileRow
+                key={`S:${f.path}`}
+                f={f}
+                active={sel?.path === f.path && sel?.staged === true}
+                onClick={() => setSel({ path: f.path, staged: true })}
+              />
+            ))
+          )}
+        </Section>
+
+        <Section title={`Unstaged (${unstaged.length})`}>
+          {unstaged.length === 0 ? (
+            <Empty />
+          ) : (
+            unstaged.map((f) => (
+              <FileRow
+                key={`U:${f.path}`}
+                f={f}
+                active={sel?.path === f.path && sel?.staged === false}
+                onClick={() => setSel({ path: f.path, staged: false })}
+              />
+            ))
+          )}
+        </Section>
+      </div>
+
+      <div>
+        <h3>Diff {sel ? `— ${sel.path} (${sel.staged ? "staged" : "unstaged"})` : ""}</h3>
+        <pre
+          style={{
+            whiteSpace: "pre-wrap",
+            background: "#0b0b0b",
+            color: "#ddd",
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            padding: 12,
+            borderRadius: 8,
+            minHeight: 300,
+            outline: "1px solid #222",
+            overflow: "auto",
+          }}
+        >
+          {diff || "No diff to show."}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: React.PropsWithChildren<{ title: string }>) {
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div style={{ fontWeight: 600, marginBottom: 6 }}>{title}</div>
+      <div style={{ border: "1px solid #ddd", borderRadius: 8, overflow: "hidden" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+function Empty() {
+  return <div style={{ padding: 8, opacity: 0.7 }}>—</div>;
+}
+
+function FileRow({ f, active, onClick }: { f: FileChange; active: boolean; onClick: () => void }) {
+  const badge = f.status;
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        width: "100%",
+        textAlign: "left",
+        padding: "6px 8px",
+        background: active ? "#eef6ff" : "white",
+        border: 0,
+        borderBottom: "1px solid #eee",
+        cursor: "pointer",
+      }}
+    >
+      <span style={{ fontFamily: "monospace", fontSize: 12, opacity: 0.7, width: 28 }}>
+        {badge}
+      </span>
+      <span style={{ flex: 1 }}>{f.path}</span>
+      <span style={{ fontSize: 12, opacity: 0.6 }}>{f.staged ? "staged" : "unstaged"}</span>
+    </button>
+  );
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,54 @@
+import { hostRun, hasTauri } from "./host";
+
+export type FileChange = {
+  path: string;
+  staged: boolean;
+  status: string; // e.g., "M", "A", "D", "R...", "??"
+};
+
+export async function gitStatus(): Promise<FileChange[]> {
+  if (!hasTauri) throw new Error("host-unavailable");
+  // porcelain=v1, NUL-delimited for safer parsing
+  const res = await hostRun("git", ["status", "--porcelain=v1", "-z"], false);
+  if (res.status !== 0) throw new Error(res.stderr || "git status failed");
+
+  const out: FileChange[] = [];
+  const chunks = res.stdout.split("\0").filter(Boolean);
+  for (const entry of chunks) {
+    // entry is like: "XY path" (or rename: "R100 old -> new")
+    const x = entry.slice(0, 1); // index status
+    const y = entry.slice(1, 2); // worktree status
+    const rest = entry.slice(3); // path or rename form
+    let staged = false,
+      status = "";
+    if (x !== " ") {
+      staged = true;
+      status = x;
+    } else if (y !== " ") {
+      staged = false;
+      status = y;
+    }
+    // handle rename form "R... old -> new"
+    let path = rest;
+    const renameSep = " -> ";
+    if (rest.includes(renameSep)) {
+      const parts = rest.split(renameSep);
+      path = parts[1]; // show the new path
+      status = "R";
+    }
+    out.push({ path, staged, status });
+  }
+  return out;
+}
+
+export async function gitDiffFile(path: string, staged: boolean): Promise<string> {
+  if (!hasTauri) throw new Error("host-unavailable");
+  const baseArgs = ["diff", "--no-color", "--unified=3"];
+  const args = staged ? [...baseArgs, "--staged", "--", path] : [...baseArgs, "--", path];
+  const res = await hostRun("git", args, false);
+  if (res.status !== 0) {
+    // If file is new and unstaged, diff may be empty; return stderr only if it’s meaningful
+    return res.stdout || res.stderr || "";
+  }
+  return res.stdout || "";
+}

--- a/tests/git_status_parse.spec.ts
+++ b/tests/git_status_parse.spec.ts
@@ -1,0 +1,6 @@
+import { describe, it, expect } from "vitest";
+
+// Placeholder unit: ensure test suite stays wired.
+describe("git status parse placeholder", () => {
+  it("runs", () => expect(true).toBe(true));
+});


### PR DESCRIPTION
## Summary
- add git helpers for status and file diff
- create Workspace pane to show staged/unstaged files and unified diffs
- wire Workspace pane into main app
- document Workspace & Diff features

## Testing
- `npm run build`
- `npm test`
- `npm run tauri:check`


------
https://chatgpt.com/codex/tasks/task_e_68bf48d9c214832083a340291c1f01eb