### PR TITLE
feat(conflicts): hunk-level preview + polish; chore(host): dev harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ cargo run --features host --manifest-path src-tauri/Cargo.toml
 
 Runs are **dry-run** by default. The host restricts filesystem access to `ade/flows/` and `kit/flows/`, only allows `git`, `gh`, `python3`, and `bash` commands, enforces a ~60s timeout, and caps output at ~200 KB.
 
+### Tauri dev harness
+
+Run the full app (host + UI) in one command:
+
+```bash
+npm run tauri:dev
+```
+
+This launches Vite and the Tauri host with the safe runner.
+Conflict Preview now supports an optional **hunk-level** estimator (checkbox) which may take longer on large refs.
+
 ## Select PRs → Merge Train
 
 - Reload PRs (needs host & `gh`)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest run",
-    "tauri:check": "cargo check --manifest-path src-tauri/Cargo.toml"
+    "tauri:check": "cargo check --manifest-path src-tauri/Cargo.toml",
+    "tauri:dev": "tauri dev --features host",
+    "tauri:build": "tauri build --features host"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -23,6 +25,7 @@
     
     "typescript": "^5.5.4",
     "vite": "^5.4.0",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "@tauri-apps/cli": "^1.5.9"
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,11 @@
 {
-  "package": { "productName": "ADE-Workbench", "version": "0.0.1" },
+  "build": {
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist",
+    "beforeDevCommand": "npm run dev"
+  },
   "tauri": {
-    "allowlist": { "all": false, "shell": { "all": false } }
-  }
+    "allowlist": { "all": false }
+  },
+  "package": { "productName": "ADE-Workbench", "version": "0.0.1" }
 }

--- a/src/components/ConflictPane.tsx
+++ b/src/components/ConflictPane.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { hasTauri } from "../lib/host";
-import { listChangedFiles, buildOverlapMatrix, matrixToCSV } from "../lib/conflict";
+import {
+  listChangedFiles,
+  buildOverlapMatrix,
+  listHunks,
+  buildHunkOverlap,
+  matrixToCSV,
+} from "../lib/conflict";
 import { loadFlowVars } from "../lib/flowInputs";
 
 export function ConflictPane() {
@@ -21,6 +27,10 @@ export function ConflictPane() {
   const [matrix, setMatrix] = React.useState<number[][]>([]);
   const [order, setOrder] = React.useState<string[]>([]);
   const [totals, setTotals] = React.useState<number[]>([]);
+  const [hunkWanted, setHunkWanted] = React.useState(false);
+  const [hunkMatrix, setHunkMatrix] = React.useState<number[][]>([]);
+  const [hunkTotals, setHunkTotals] = React.useState<number[]>([]);
+  const [hotPairs, setHotPairs] = React.useState<Array<{ a: string; b: string; score: number }>>([]);
 
   const refsArr = React.useMemo(() => {
     const arr = rawRefs.split(/\s+/).map((s) => s.trim()).filter(Boolean);
@@ -28,40 +38,52 @@ export function ConflictPane() {
   }, [rawRefs]);
 
   async function analyze() {
-    if (!hasTauri) {
-      setErr("Host unavailable");
-      return;
-    }
-    if (!refsArr.length) {
-      setErr("No refs specified");
-      return;
-    }
-    setErr("");
-    setBusy(true);
+    if (!hasTauri) { setErr("Host unavailable"); return; }
+    if (!refsArr.length) { setErr("No refs specified"); return; }
+    setErr(""); setBusy(true);
     try {
-      const results: Record<string, string[]> = {};
+      // simple concurrency limiter
+      const results: Record<string,string[]> = {};
       const queue = [...refsArr];
-      const workers = Array.from(
-        { length: Math.min(3, refsArr.length) },
-        async function worker() {
-          while (queue.length) {
-            const r = queue.shift()!;
-            try {
-              results[r] = await listChangedFiles(base, r);
-            } catch (e) {
-              results[r] = [];
-              console.error("diff error", r, e);
-            }
-          }
+      const workers = Array.from({ length: Math.min(3, refsArr.length) }, async function worker() {
+        while (queue.length) {
+          const r = queue.shift()!;
+          try { results[r] = await listChangedFiles(base, r); }
+          catch (e) { results[r] = []; console.error("diff error", r, e); }
         }
-      );
+      });
       await Promise.all(workers);
       setRefs(refsArr);
       setFilesByRef(results);
       const { matrix, totals, order } = buildOverlapMatrix(refsArr, results);
-      setMatrix(matrix);
-      setTotals(totals);
-      setOrder(order);
+      setMatrix(matrix); setTotals(totals); setOrder(order);
+
+      // Optional hunk-level scan (slower): collect hunks per (ref,file) then compute overlap
+      if (hunkWanted) {
+        const H: Record<string, Record<string, Array<{start:number;end:number}>>> = {};
+        const tasks: Array<Promise<void>> = [];
+        const limit = Math.max(1, Math.min(6, refsArr.length * 2));
+        const refFiles: Array<{ r: string; f: string }> = [];
+        for (const r of refsArr) for (const f of results[r] || []) refFiles.push({ r, f });
+        let i = 0;
+        async function next() {
+          const item = refFiles[i++]; if (!item) return;
+          const { r, f } = item;
+          try {
+            const hunks = await listHunks(base, r, f);
+            (H[r] ||= {})[f] = hunks;
+          } catch (e) {
+            console.error("hunk error", r, f, e);
+          }
+          return next();
+        }
+        for (let k = 0; k < limit; k++) tasks.push(next());
+        await Promise.all(tasks);
+        const { matrix: HM, totals: HT, hotPairs } = buildHunkOverlap(refsArr, results, H);
+        setHunkMatrix(HM); setHunkTotals(HT); setHotPairs(hotPairs);
+      } else {
+        setHunkMatrix([]); setHunkTotals([]); setHotPairs([]);
+      }
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -71,18 +93,15 @@ export function ConflictPane() {
 
   function copyCSV() {
     const csv = matrixToCSV(refs, matrix);
-    navigator.clipboard
-      .writeText(csv)
-      .catch((e) =>
-        setErr(`Copy failed: ${e instanceof Error ? e.message : String(e)}`)
-      );
+    navigator.clipboard.writeText(csv).catch(e => setErr(`Copy failed: ${e instanceof Error ? e.message : String(e)}`));
   }
   function copyOrder() {
-    navigator.clipboard
-      .writeText(order.join(" "))
-      .catch((e) =>
-        setErr(`Copy failed: ${e instanceof Error ? e.message : String(e)}`)
-      );
+    navigator.clipboard.writeText(order.join(" ")).catch(e => setErr(`Copy failed: ${e instanceof Error ? e.message : String(e)}`));
+  }
+  function copyHunkCSV() {
+    if (!hunkMatrix.length) return;
+    const csv = matrixToCSV(refs, hunkMatrix);
+    navigator.clipboard.writeText(csv).catch(e => setErr(`Copy failed: ${e instanceof Error ? e.message : String(e)}`));
   }
 
   return (
@@ -107,6 +126,10 @@ export function ConflictPane() {
             onChange={(e) => setRawRefs(e.target.value)}
             style={{ width: "100%" }}
           />
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={hunkWanted} onChange={e => setHunkWanted(e.target.checked)} />
+          Estimate hunk overlaps (slower)
         </label>
         <button onClick={analyze} disabled={busy || !refsArr.length}>
           {busy ? "Analyzing…" : "Analyze"}
@@ -169,6 +192,47 @@ export function ConflictPane() {
               </tbody>
             </table>
           </div>
+          {hunkMatrix.length > 0 && (
+            <>
+              <div style={{ marginTop: 16, display: "flex", gap: 8, alignItems: "center" }}>
+                <strong>Hunk overlap (lines):</strong>
+                <button onClick={copyHunkCSV}>Copy CSV (hunks)</button>
+              </div>
+              <div style={{ marginTop: 8, overflowX: "auto" }}>
+                <table style={{ borderCollapse: "collapse", minWidth: 480 }}>
+                  <thead>
+                    <tr>
+                      <th style={{ textAlign: "left", padding: 6 }}>ref</th>
+                      {refs.map(r => <th key={r} style={{ padding: 6 }}>{r}</th>)}
+                      <th style={{ padding: 6 }}>sum</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {refs.map((r, i) => (
+                      <tr key={r}>
+                        <td style={{ padding: 6, fontWeight: 600 }}>{r}</td>
+                        {refs.map((c, j) => (
+                          <td key={c} style={{ padding: 6, textAlign: "center", background: i===j ? "#fafafa" : "white", border: "1px solid #eee" }}>
+                            {i===j ? "—" : hunkMatrix[i]?.[j] ?? 0}
+                          </td>
+                        ))}
+                        <td style={{ padding: 6, textAlign: "center" }}>{hunkTotals[i] ?? 0}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div style={{ marginTop: 10 }}>
+                <strong>Spiciest pairs:</strong>
+                <ul style={{ marginTop: 6 }}>
+                  {hotPairs.slice(0, 10).map(p => (
+                    <li key={`${p.a}->${p.b}`}><code>{p.a}</code> × <code>{p.b}</code> — {p.score}</li>
+                  ))}
+                  {hotPairs.length === 0 && <li>—</li>}
+                </ul>
+              </div>
+            </>
+          )}
 
           <details style={{ marginTop: 10 }}>
             <summary>Files per ref</summary>

--- a/src/lib/conflict.ts
+++ b/src/lib/conflict.ts
@@ -1,31 +1,58 @@
 import { hostRun, hasTauri } from "./host";
 
+/** List changed files for ref vs base, with rename detection; include deletions. */
 export async function listChangedFiles(base: string, ref: string): Promise<string[]> {
   if (!hasTauri) throw new Error("host-unavailable");
-  // Use rename detection so refactors are surfaced; include deletions (D) to catch delete vs modify conflicts.
-  const args = [
-    "diff",
-    "--name-only",
-    "--find-renames",
-    "--diff-filter=ACMRD",
-    `${base}..${ref}`,
-  ];
+  const args = ["diff", "--name-only", "--find-renames", "--diff-filter=ACMRD", `${base}..${ref}`];
   const res = await hostRun("git", args, false);
   if (res.status !== 0) throw new Error(res.stderr || `git diff failed for ${ref}`);
-  // De-duplicate filenames (some configs can repeat paths). Preserve input order.
+  // De-duplicate and preserve order
   const seen = new Set<string>();
   const out: string[] = [];
   for (const line of res.stdout.split("\n")) {
     const f = line.trim();
-    if (!f) continue;
-    if (!seen.has(f)) {
-      seen.add(f);
-      out.push(f);
-    }
+    if (!f || seen.has(f)) continue;
+    seen.add(f);
+    out.push(f);
   }
   return out;
 }
 
+/** Parse @@ hunk headers from a --unified=0 diff. Use the '-' (base) side for cross-ref comparison. */
+export function parseUnifiedHunks(diffText: string): Array<{ start: number; end: number }> {
+  // @@ -a,b +c,d @@  (b or d may be omitted, which implies 1)
+  const re = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/gm;
+  const ranges: Array<{ start: number; end: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(diffText))) {
+    const a = Number(m[1]);
+    const b = m[2] ? Number(m[2]) : 1;
+    if (b <= 0) continue; // nothing changed on base side (e.g., pure insertion)
+    const start = a;
+    const end = a + b - 1; // inclusive
+    ranges.push({ start, end });
+  }
+  return ranges;
+}
+
+/** Get base-relative hunk ranges for a single file under ref vs base. */
+export async function listHunks(base: string, ref: string, file: string) {
+  if (!hasTauri) throw new Error("host-unavailable");
+  const args = [
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--no-ext-diff",
+    `${base}..${ref}`,
+    "--",
+    file,
+  ];
+  const res = await hostRun("git", args, false);
+  if (res.status !== 0) return []; // treat failures as no hunks (we’ll degrade gracefully)
+  return parseUnifiedHunks(res.stdout);
+}
+
+/** File-level overlap matrix and greedy low-conflict order. */
 export function buildOverlapMatrix(
   refs: string[],
   filesByRef: Record<string, string[]>
@@ -66,8 +93,53 @@ export function buildOverlapMatrix(
   return { matrix, totals, order };
 }
 
+/** Hunk-level overlap: sum of overlapping base-line lengths across shared files. */
+export function buildHunkOverlap(
+  refs: string[],
+  filesByRef: Record<string, string[]>,
+  hunks: Record<string, Record<string, Array<{ start: number; end: number }>>>
+): {
+  matrix: number[][];
+  totals: number[];
+  hotPairs: Array<{ a: string; b: string; score: number }>;
+} {
+  const n = refs.length;
+  const matrix: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
+  const totals = Array(n).fill(0);
+
+  const overlapLen = (A: { start: number; end: number }, B: { start: number; end: number }) =>
+    Math.max(0, Math.min(A.end, B.end) - Math.max(A.start, B.start) + 1);
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      let score = 0;
+      const ri = refs[i],
+        rj = refs[j];
+      const filesI = new Set(filesByRef[ri] || []);
+      const filesJ = new Set(filesByRef[rj] || []);
+      for (const f of filesI) {
+        if (!filesJ.has(f)) continue;
+        const hi = hunks[ri]?.[f] || [];
+        const hj = hunks[rj]?.[f] || [];
+        for (const a of hi) for (const b of hj) score += overlapLen(a, b);
+      }
+      matrix[i][j] = matrix[j][i] = score;
+    }
+  }
+  for (let i = 0; i < n; i++) totals[i] = matrix[i].reduce((s, x) => s + x, 0);
+
+  const hotPairs: Array<{ a: string; b: string; score: number }> = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (matrix[i][j] > 0) hotPairs.push({ a: refs[i], b: refs[j], score: matrix[i][j] });
+    }
+  }
+  hotPairs.sort((x, y) => y.score - x.score);
+  return { matrix, totals, hotPairs };
+}
+
+/** CSV export with quoting. */
 export function matrixToCSV(refs: string[], matrix: number[][]): string {
-  // CSV with simple quoting for refs (handle commas/spaces).
   const q = (s: string) => `"${String(s).replace(/"/g, '""')}"`;
   const header = [q("ref"), ...refs.map(q)].join(",");
   const rows = refs.map((r, i) => [q(r), ...matrix[i]].join(","));


### PR DESCRIPTION
## Summary
- add hunk-level diff utilities and overlap scoring
- expose optional hunk estimator in Conflict Preview with CSV export
- wire up Tauri dev harness and scripts

## Testing
- `npm test`
- `npm run build`
- `npm run tauri:check`


------
https://chatgpt.com/codex/tasks/task_e_68bf57988f8c83209f79a631a4e7432e